### PR TITLE
Add option to control the space between @ & the directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ run the above command in your project's root directory will beautify all the bla
 - Automatically Indents markup inside directives
 - Automatically add spacing to blade templating markers
 - Support all [HTML Beautifier Options](https://github.com/beautify-web/js-beautify#css--html)
+- To remove the space between `@` and the directive set `space_after_directive` to `false`
 
 
   
@@ -50,7 +51,7 @@ run the above command in your project's root directory will beautify all the bla
 
 - [x] Add indendt for `@case`
 - [ ] Support single custom directive
-- [ ] Add options to customize space between `@` & directive
+- [x] Add options to customize space between `@` & directive
 
   
 ## Contributing

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -255,6 +255,7 @@ function Beautifier(source_text, options, js_beautify, css_beautify) {
   this._is_wrap_attributes_aligned_multiple = (this._options.wrap_attributes === 'aligned-multiple');
   this._is_wrap_attributes_preserve = this._options.wrap_attributes.substr(0, 'preserve'.length) === 'preserve';
   this._is_wrap_attributes_preserve_aligned = (this._options.wrap_attributes === 'preserve-aligned');
+  this._is_space_after_directive = (options.html.space_after_directive) ?? true
 }
 Beautifier.prototype.prepare_blade = function(source_text){
   source_text = source_text || '';
@@ -310,7 +311,7 @@ Beautifier.prototype.prepare_blade = function(source_text){
           case 'stop':
               return "</blade " + d + c + ">";
           case 'section':
-              if(c.match(/\|\(.*%2C.*\)/i)){
+              if(c.match(/\|[%20]*\(.*%2C.*\)/i)){
                 return "<blade " + d + c + "/>";
               } else {
                 return "<blade " + d + c + ">";
@@ -337,6 +338,7 @@ Beautifier.prototype.prepare_blade = function(source_text){
   return source_text;
 }
 Beautifier.prototype.return_blade = function(sweet_code, printer){
+  var _is_space_after_directive = this._is_space_after_directive;
   sweet_code = sweet_code.replace(/.*(<blade tempOpenTag>).*\n/g, '');
   sweet_code = sweet_code.replace(/^([ \t]*)<\/?blade\s*([a-z]+)\|?([^>\/]+)?\/?>$/gim, function (m, s, d, c) {
     if (c) {
@@ -349,6 +351,9 @@ Beautifier.prototype.return_blade = function(sweet_code, printer){
     }
     if (!s) {
         s = "";
+    }
+    if(c.trim() && _is_space_after_directive) {
+      d = d + " "
     }
     return s + "@" + d + c.trim();
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-beautify-with-blade",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A fork from js-beautify to support Blade templates",
   "main": "js/index.js",
   "scripts": {


### PR DESCRIPTION
Now it enabled by default but you can remove the space by setting `space_after_directive` to `false`